### PR TITLE
verushash-node added to module.exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+module.exports = require('bindings')('verushash.node');
+


### PR DESCRIPTION
Appearantly, you cannot really control wether verushash will go to `s-nomp/node_modules` or `s-nomp/node_modules/stratum-pool/node_modules` after you `npm install` it - it probably is for the same reason that both locations are actually added in the s-nomp `package.json` file in the 'start' command.

It worked for me without the `index.js` file when you use `npm start` (over `pm2`) and the module is in `s-nomp/node_modules` over `s-nomp/node_modules/stratum-pool/node_modules`. Also, having this file won't hurt.